### PR TITLE
Simplify unit tests & fix bug when forecast passed to create_summary was None

### DIFF
--- a/src/neptune_prophet/impl/__init__.py
+++ b/src/neptune_prophet/impl/__init__.py
@@ -107,7 +107,7 @@ def create_summary(
         "serialized_model": get_serialized_model(model),
     }
 
-    prophet_summary["dataframes"] = {"forecast": File.as_html(fcst)}
+    prophet_summary["dataframes"] = {}
 
     if df is not None:
         prophet_summary["dataframes"]["df"] = File.as_html(df)
@@ -131,6 +131,8 @@ def create_summary(
             }
     elif log_charts:
         prophet_summary["diagnostics_charts"] = create_forecast_plots(model, fcst, log_interactive=log_interactive)
+
+    prophet_summary["dataframes"] = {"forecast": File.as_html(fcst)}
 
     return prophet_summary
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,28 +1,29 @@
 import pandas as pd
 import pytest
+
 from prophet import Prophet
 
 
 @pytest.fixture(scope="session")
 def dataset():
-    yield pd.read_csv("tests/dataset.csv")
+    return pd.read_csv("tests/dataset.csv")
 
 
 @pytest.fixture(scope="session")
 def model(dataset):
     prophet_model = Prophet()
     prophet_model.fit(dataset)
-    yield prophet_model
+    return prophet_model
 
 
 @pytest.fixture(scope="session")
 def forecast(model):
     future = model.make_future_dataframe(periods=365)
     forecast = model.predict(future)
-    yield forecast
+    return forecast
 
 
 @pytest.fixture(scope="session")
 def predicted(model, dataset):
     predicted = model.predict(dataset)
-    yield predicted
+    return predicted

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,6 +1,5 @@
 import json
 import tempfile
-import time
 from pathlib import Path
 
 import pytest
@@ -22,33 +21,91 @@ except ImportError:
     from neptune import init_run
 
 
-WAIT_FOR_LEADERBOARD = 15
-
-
-def _test_with_run_initialization(*, pre, post, pre_kwargs=None, post_kwargs=None):
-    if pre_kwargs is None:
-        pre_kwargs = {}
-
-    if post_kwargs is None:
-        post_kwargs = {}
-
+def test_get_model_config(model):
     with init_run() as run:
-        pre(run, **pre_kwargs)
-        time.sleep(WAIT_FOR_LEADERBOARD)
-        post(run, **post_kwargs)
+        run["data"] = get_model_config(model)
+        run.wait()
+        _test_structure_get_model_config(run)
+
+
+def test_get_serialized_model(model):
+    with init_run() as run:
+        run["data"] = get_serialized_model(model)
+        run.wait()
+        _test_structure_get_serialized_model(run)
+
+
+def test_get_forecast_components(model, forecast):
+    with init_run() as run:
+        run["data"] = get_forecast_components(model, forecast)
+        run.wait()
+        _test_structure_get_forecast_components(run)
+
+
+@pytest.mark.parametrize("log_interactive", [False, True])
+def test_create_forecast_plots(model, forecast, log_interactive):
+    with init_run() as run:
+        run["data"] = create_forecast_plots(
+            model,
+            forecast,
+            log_interactive=log_interactive,
+        )
+        run.wait()
+        _test_structure_create_forecast_plots(run, interactive=log_interactive)
+
+
+@pytest.mark.parametrize("log_interactive", [False, True])
+def test_create_residual_diagnostics_plots(dataset, predicted, log_interactive):
+    with init_run() as run:
+        run["data"] = create_residual_diagnostics_plots(predicted, dataset.y, log_interactive=log_interactive)
+        run.wait()
+        _test_structure_create_residual_diagnostics_plots(run, interactive=log_interactive)
+
+
+@pytest.mark.parametrize(
+    "log_interactive, with_forecast, log_charts",
+    [
+        (True, True, True),
+        (False, True, True),
+        (False, False, True),
+        (False, False, False),
+    ],
+)
+def test_create_summary(model, dataset, with_forecast, log_interactive, log_charts):
+    with init_run() as run:
+        if with_forecast:
+            forecast = model.predict(dataset)
+        else:
+            forecast = None
+
+        run["data"] = create_summary(
+            model, df=dataset, fcst=forecast, log_interactive=log_interactive, log_charts=log_charts
+        )
+        run.wait()
+
+        assert run.exists("data")
+        assert run.exists("data/dataframes")
+
+        _test_structure_get_model_config(run, "data/model/model_config")
+        _test_structure_get_serialized_model(run, "data/model/serialized_model")
+
+        assert run.exists("data/diagnostics_charts") == log_charts
+
+        if log_charts:
+            _test_structure_create_forecast_plots(
+                run=run, base_namespace="data/diagnostics_charts", interactive=log_interactive
+            )
+            _test_structure_create_residual_diagnostics_plots(
+                run=run,
+                interactive=log_interactive,
+                base_namespace="data/diagnostics_charts/residuals_diagnostics_charts",
+            )
 
 
 def _test_structure_get_model_config(run, base_namespace="data"):
     assert run.exists(base_namespace)
     assert run.exists(f"{base_namespace}/history_dates")
     assert run[f"{base_namespace}/history_dates"].fetch_extension() == "html"
-
-
-def test_get_model_config(model):
-    def initialize(run):
-        run["data"] = get_model_config(model)
-
-    _test_with_run_initialization(pre=initialize, post=_test_structure_get_model_config)
 
 
 def _test_structure_get_serialized_model(run, base_namespace="data"):
@@ -61,24 +118,10 @@ def _test_structure_get_serialized_model(run, base_namespace="data"):
             _ = json.load(handler)
 
 
-def test_get_serialized_model(model):
-    def initialize(run):
-        run["data"] = get_serialized_model(model)
-
-    _test_with_run_initialization(pre=initialize, post=_test_structure_get_serialized_model)
-
-
 def _test_structure_get_forecast_components(run, base_namespace="data"):
     assert run.exists(base_namespace)
     for column_name in ["yhat", "yhat_lower", "yhat_upper", "trend"]:
         assert run.exists(f"{base_namespace}/{column_name}")
-
-
-def test_get_forecast_components(model, forecast):
-    def initialize(run):
-        run["data"] = get_forecast_components(model, forecast)
-
-    _test_with_run_initialization(pre=initialize, post=_test_structure_get_forecast_components)
 
 
 def _test_plot(run, namespace, interactive):
@@ -94,20 +137,6 @@ def _test_structure_create_forecast_plots(run, interactive, base_namespace="data
     _test_structure_get_forecast_components(run, base_namespace=base_namespace)
 
 
-@pytest.mark.parametrize("log_interactive", [False, True])
-def test_create_forecast_plots(model, forecast, log_interactive):
-    def initialize(run):
-        run["data"] = create_forecast_plots(
-            model,
-            forecast,
-            log_interactive=log_interactive,
-        )
-
-    _test_with_run_initialization(
-        pre=initialize, post=_test_structure_create_forecast_plots, post_kwargs={"interactive": log_interactive}
-    )
-
-
 def _test_structure_create_residual_diagnostics_plots(run, interactive, base_namespace="data"):
     assert run.exists(base_namespace)
     _test_plot(run, f"{base_namespace}/histogram", interactive=False)
@@ -115,54 +144,3 @@ def _test_structure_create_residual_diagnostics_plots(run, interactive, base_nam
     _test_plot(run, f"{base_namespace}/qq_plot", interactive=interactive)
     _test_plot(run, f"{base_namespace}/actual_vs_normalized_errors", interactive=interactive)
     _test_plot(run, f"{base_namespace}/ds_vs_normalized_errors", interactive=interactive)
-
-
-@pytest.mark.parametrize("log_interactive", [False, True])
-def test_create_residual_diagnostics_plots(dataset, predicted, log_interactive):
-    def initialize(run):
-        run["data"] = create_residual_diagnostics_plots(predicted, dataset.y, log_interactive=log_interactive)
-
-    _test_with_run_initialization(
-        pre=initialize,
-        post=_test_structure_create_residual_diagnostics_plots,
-        post_kwargs={"interactive": log_interactive},
-    )
-
-
-@pytest.mark.parametrize("log_interactive", [False, True])
-def test_create_summary(model, dataset, predicted, log_interactive):
-    def initialize(run):
-        run["data"] = create_summary(model, df=dataset, fcst=predicted, log_interactive=log_interactive)
-
-    def assert_structure(run, interactive):
-        assert run.exists("data")
-        assert run.exists("data/dataframes")
-
-        _test_structure_get_model_config(run, "data/model/model_config")
-        _test_structure_get_serialized_model(run, "data/model/serialized_model")
-
-        assert run.exists("data/diagnostics_charts")
-        _test_structure_create_forecast_plots(
-            run=run, base_namespace="data/diagnostics_charts", interactive=interactive
-        )
-        _test_structure_create_residual_diagnostics_plots(
-            run=run, interactive=interactive, base_namespace="data/diagnostics_charts/residuals_diagnostics_charts"
-        )
-
-    _test_with_run_initialization(pre=initialize, post=assert_structure, post_kwargs={"interactive": log_interactive})
-
-
-def test_create_summary_no_charts(model, dataset, predicted):
-    def initialize(run):
-        run["data"] = create_summary(model, df=dataset, fcst=predicted, log_charts=False)
-
-    def assert_structure(run):
-        assert run.exists("data")
-        assert run.exists("data/dataframes")
-
-        _test_structure_get_model_config(run, "data/model/model_config")
-        _test_structure_get_serialized_model(run, "data/model/serialized_model")
-
-        assert not run.exists("data/diagnostics_charts")
-
-    _test_with_run_initialization(pre=initialize, post=assert_structure)


### PR DESCRIPTION
* I refactored the code to simplify the test structure. The structure we had used was a factory pattern that made the code pretty complicated. Already for the second time, I spent over half an hour debugging the tests to track a problem (previously it was a failing test when there was no bug in the code, this time passing the test when we had a bug). I decided to simplify the code in the tests so that it is more straightforward at the code of some code duplication. It is consistent with common recommendations that the tests should not include additional logic that could blurry interpretation of their results.
* I'm also fixing a bug in the code. We assumed that the data provided to `create_summary` was not-None, but the arguments allowed for None input (it was a default!).