### PR TITLE
Bumped `plotly` and unpinned `matplotlib`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-prophet 1.0.1
+
+### Changes
+- Bumped `plotly` and unpinned `matplotlib` ([#33](https://github.com/neptune-ai/neptune-prophet/pull/33))
+
 ## neptune-prophet 1.0.0
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python = "^3.7"
 importlib-metadata = { version = "*", python = "<3.8" }
 
 # Base requirements
-matplotlib = "<=3.4.3"
+matplotlib = "*"
 numpy = "*"
 pandas = "<2.0.0"
 prophet = ">=1.0"
@@ -26,7 +26,7 @@ statsmodels = ">=0.13.0"
 pre-commit = { version = "*", optional = true }
 pytest = { version = ">=5.0", optional = true }
 pytest-cov = { version = "2.10.1", optional = true }
-plotly = { version = "*", optional = true }
+plotly = { version = ">=5.18.0", optional = true }
 neptune = { version = ">=1.0.0", optional = true }
 
 [tool.poetry.extras]


### PR DESCRIPTION
Plotly release [5.18.0](https://github.com/plotly/plotly.py/releases/tag/v5.18.0) fixes the issue with matplotlib `get_offset_position()` [#4372](https://github.com/plotly/plotly.py/pull/4372).

With this, matplotlib can now be unpinned and plotly needs to be bumped to >=5.18