### PR TITLE
Expanded e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.8", "3.11"]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Expanded tests to Windows and Python 3.8-3.11.

Matplotlib installation works on Windows runners now that the constraints have been removed