### PR TITLE
chore: Constrain numpy dependency to <2.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         args: [--settings-path, pyproject.toml]
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 24.4.2
     hooks:
       - id: black
         args: [--config, pyproject.toml]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-prophet 1.0.2
+
+### Changes
+- Constrained `numpy` to `<2.0.0` ([#35](https://github.com/neptune-ai/neptune-prophet/pull/35))
+
 ## neptune-prophet 1.0.1
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ importlib-metadata = { version = "*", python = "<3.8" }
 
 # Base requirements
 matplotlib = "*"
-numpy = "*"
+numpy = "<2.0.0"
 pandas = "<2.0.0"
 prophet = ">=1.0"
 scipy = "*"


### PR DESCRIPTION
Prophet uses methods deprecated in `numpy>=2.0.0` (https://github.com/facebook/prophet/issues/2588)

This PR constrains `numpy` to `2.0.0` until there's a fix from Prophet's end